### PR TITLE
Add CP/M-80 disks format of Quorum ZX Spectrum clone

### DIFF
--- a/src/greaseweazle/data/diskdefs.cfg
+++ b/src/greaseweazle/data/diskdefs.cfg
@@ -1068,3 +1068,12 @@ disk zx.trdos.640
         h = 0
     end
 end
+
+disk zx.quorum.800
+    cyls = 80
+    heads = 2
+    tracks * ibm.mfm
+        secs = 5
+        bps = 1024
+    end
+end


### PR DESCRIPTION
Quorum is Russian ZX Spectrum clone from 90s, which used CP/M-80 instead of TR-DOS.
AFAIK The same disk format was also used in "Korvet" Soviet CP/M computer, but I have no "Korvet" disks to test.